### PR TITLE
Docs/Dev: Makefile dev target and README coverage/hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-.PHONY: help install dev lint fmt test run smoke pack
+.PHONY: help install dev lint fmt test run smoke pack hooks
 
 help:
-	@echo "Targets: install dev lint fmt test run smoke pack"
+	@echo "Targets: install dev lint fmt test run smoke pack hooks"
 
 install:
 	python -m pip install --upgrade pip
 	pip install -r requirements.txt || true
 
 dev: install
-	pip install ruff==0.6.9 black==24.8.0 pytest==8.3.2
+	pip install ruff==0.6.9 black==24.8.0 pytest==8.3.2 pytest-cov==5.0.0
 
 lint:
 	ruff check .
@@ -27,3 +27,8 @@ smoke:
 
 pack:
 	tar -czf cordee-$(shell date +%F).tgz .
+
+# Install git hooks for lint/format (pre-commit)
+hooks:
+	@command -v pre-commit >/dev/null 2>&1 || pip install pre-commit
+	pre-commit install

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ cd cordee
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 
+# Option Makefile (installe aussi ruff/black/pytest/pytest-cov)
+make dev
+
 # Lancer le serveur en dev
 python src/rag_http.py
 
@@ -43,6 +46,11 @@ Tests locaux (offline, sans téléchargement de modèles) :
 ```bash
 # Ajoute src au PYTHONPATH via pytest.ini, active le mode offline
 CORDEE_CI=1 pytest -q
+
+# Avec rapport de couverture (aligné CI, seuil 70%)
+CORDEE_CI=1 pytest -q \
+  --cov=src --cov=tests --cov-report=term-missing \
+  --cov-report=xml:coverage.xml --cov-fail-under=70
 ```
 
 Alternative : installation sous /opt/valexa (voir le bloc juste en dessous).
@@ -120,8 +128,11 @@ Notes CI:
 ## Contrib (pre-commit)
 Active les hooks de lint/format locaux pour aligner avec la CI :
 ```bash
-pip install pre-commit
-pre-commit install
+# via Makefile
+make hooks
+
+# ou manuellement
+pip install pre-commit && pre-commit install
 # Exécuter sur tout le dépôt si besoin
 pre-commit run -a
 ```


### PR DESCRIPTION
This PR makes small dev/documentation improvements:\n\n- Makefile: add pytest-cov to the dev target and a hooks target to install pre-commit hooks.\n- README: document make dev and make hooks, and add the coverage test command aligned with CI.\n\nNo runtime logic changes. API, CI coverage, and .gitignore are already on main.