### PR TITLE
docs: v0.2.0 changelog + release badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+Toutes les modifications notables de ce projet sont documentées ici.
+
+Ce fichier suit librement les principes de Keep a Changelog et le versionnage SemVer.
+
+## [v0.2.0] - 2025-09-15
+
+- Ajouts
+  - Cible Makefile `ci-local` qui enchaîne lint (ruff), format check (black), tests offline avec couverture (≥70%), puis e2e (smoke).
+  - Workflow GitHub Actions `ci-local` (workflow_dispatch + push sur branche `ci-local`), compatible `act`.
+
+- Changements
+  - Script `scripts/run_smoke_e2e.sh` plus robuste: lance `uvicorn` avec `PYTHONPATH=src`, sélectionne un port libre, force l’embedder dummy et le mode offline.
+  - API `src/rag_http.py`: lecture dynamique du mode CI via l’environnement, désactivation de la télémétrie Chroma par défaut, support des variables `CHROMA_*` en plus des historiques `RAG_*`.
+  - Exemple d’environnement systemd mis à jour pour préférer `CHROMA_*`.
+
+- Qualité / DX
+  - Résolution de conflits Makefile + harmonisation des cibles.
+  - Lint/format appliqués; tests passent localement avec ~85% de couverture.
+
+- Notes
+  - Aucun changement de comportement en mode en ligne “classique”. Le mode offline + dummy n’est activé qu’en CI/e2e.
+  - PR associée: #15.
+
+[v0.2.0]: https://github.com/Djabolum/cordee/releases/tag/v0.2.0
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cordée
 
 [![CI](https://github.com/Djabolum/cordee/actions/workflows/ci.yml/badge.svg)](https://github.com/Djabolum/cordee/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/Djabolum/cordee?logo=github)](https://github.com/Djabolum/cordee/releases)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 
@@ -149,3 +150,7 @@ Hooks actifs : Ruff (avec `--fix`) et Black (versions alignées avec la CI).
 ---
 
 Bon vol ✌️
+
+---
+
+Changelog: voir CHANGELOG.md


### PR DESCRIPTION
Ajoute CHANGELOG.md (v0.2.0) et un badge de release dans le README.\n\n- CHANGELOG détaillant : cible Makefile ci-local, workflow ci-local, améliorations e2e, tweaks API (mode CI dynamique, télémétrie off), exemples systemd.\n- README : badge de release et lien vers CHANGELOG.\n\nAucun impact runtime. Merge sans risque.