### PR TITLE
ci(ci-local): run on PRs to main (prepare required check)

### DIFF
--- a/.github/workflows/ci-local.yml
+++ b/.github/workflows/ci-local.yml
@@ -2,6 +2,8 @@ name: CI Local
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ main ]
   push:
     branches: [ "ci-local" ]
 
@@ -33,4 +35,3 @@ jobs:
 
       - name: Run ci-local target
         run: make ci-local
-


### PR DESCRIPTION
This switches CI Local workflow to run on pull_request to main so it can be set as a required status check.\n\n- Triggers: workflow_dispatch, pull_request (main), push on ci-local\n- No runtime impact apart from CI time on PRs.\n\nAfter merge, we can enforce the 'ci-local' job as required on main via rulesets.